### PR TITLE
Incorporating Greg's comments about the threshold detector

### DIFF
--- a/test_threshold_detector.py
+++ b/test_threshold_detector.py
@@ -11,7 +11,7 @@ class SetVolumeTestCase(SimpleTestCase):
 	def runTest(self, ):
 		self.sd.set_volume_threshold()
 		threshold = self.sd.volume_threshold
-		self.assertTrue(isinstance(threshold, float))
+		self.assertTrue(isinstance(threshold, int))
 		self.assertTrue(threshold != 10000)
 
 class GetVolumeTestCase(SimpleTestCase):
@@ -39,14 +39,14 @@ class DetectTimeThresholdTestCase(SimpleTestCase):
 
 class VolumeThresholdTestCase(SimpleTestCase):
 	def runTest(self, ):
-		self.sd.volume_threshold_detection(end_time=time.time() + 10)
+		self.sd.simple_detector(end_time=time.time() + 10)
 
 class TimedVolumeThresholdTestCase(SimpleTestCase):
 	def runTest(self, ):
 		start = time.time()
 		self.sd.volume_threshold = 100
 		self.sd.time_threshold = 0.5
-		self.sd.timed_volume_threshold_detection(end_time=time.time() + 10)
+		self.sd.timed_volume_detector(end_time=time.time() + 10)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/threshold_detector.py
+++ b/threshold_detector.py
@@ -30,8 +30,7 @@ class ThresholdDetector():
         self.frames                 = frames # number of frames per buffer
         self.recording_sample       = recording_sample # number of seconds to sample from
         self.stream                 = None # the PyAudio stream
-        self.alerted_threshold      = False 
-        self.was_at_threshold       = False
+        self.alerted_threshold      = False
         self.threshold_timestamp    = None  # time value set when a detector determines the volume is below the set threshold.
         self.operator               = op
         try:
@@ -161,18 +160,14 @@ class ThresholdDetector():
             if is_below_threshold and above_time_threshold and not self.alerted_threshold:
                 self.stdout('Time and volume thresholds met!')
                 self.alerted_threshold = True
-            elif is_below_threshold and not self.was_at_threshold:
+            elif is_below_threshold and self.threshold_timestamp is None:
                 self.stdout('New threshold period, counting down time threshold')
-                self.was_at_threshold = True
                 self.threshold_timestamp = time.time()
-            elif not is_below_threshold and self.was_at_threshold and self.alerted_threshold:
-                self.stdout('Seconds thresholds were met: {}'.format(time.time() - self.threshold_timestamp))
-                self.alerted_threshold = False
-                self.was_at_threshold = False
-                self.threshold_timestamp = None
             elif not is_below_threshold:
-                self.was_at_threshold = False
+                if above_time_threshold:
+                    self.stdout('Seconds thresholds were met: {}'.format(time.time() - self.threshold_timestamp))
                 self.threshold_timestamp = None
+                self.alerted_threshold = False
 
     def run(self, ):
         """ runs user set threshold detector

--- a/threshold_detector.py
+++ b/threshold_detector.py
@@ -177,7 +177,6 @@ class ThresholdDetector():
     def run(self, ):
         """ runs user set threshold detector
         """
-        time.sleep(1)
         self.detector()
 
 if __name__ == "__main__":

--- a/threshold_detector.py
+++ b/threshold_detector.py
@@ -163,13 +163,14 @@ class ThresholdDetector():
             is_below_threshold = self.detect_volume_threshold(average)
             above_time_threshold = self.detect_time_threshold()
             self.stdout(average)
-            if is_below_threshold and above_time_threshold and not self.alerted_threshold:
-                self.stdout('Time and volume thresholds met!')
-                self.alerted_threshold = True
-            elif is_below_threshold and self.threshold_timestamp is None:
-                self.stdout('New threshold period, counting down time threshold')
-                self.threshold_timestamp = time.time()
-            elif not is_below_threshold:
+            if is_below_threshold:
+                if self.threshold_timestamp is None:
+                    self.stdout('New threshold period, counting down time threshold')
+                    self.threshold_timestamp = time.time()
+                elif above_time_threshold and not self.alerted_threshold:
+                    self.stdout('Time and volume thresholds met!')
+                    self.alerted_threshold = True
+            else:
                 if above_time_threshold:
                     self.stdout('Seconds thresholds were met: {}'.format(time.time() - self.threshold_timestamp))
                 self.threshold_timestamp = None

--- a/threshold_detector.py
+++ b/threshold_detector.py
@@ -136,11 +136,16 @@ class ThresholdDetector():
         sys.stdout.write(str(output) + '\n')
         sys.stdout.flush()
 
-    def simple_detector(self, ):
+    def loop_condition(self, end_time):
+        """ For testing purposes to have an end time
+        """
+        return time.time() < end_time if end_time is not None else True
+
+    def simple_detector(self, end_time=None):
         """ Reads volumes from input audio stream and prints 0 if 
             volume is below the threshold, otherwise prints 1
         """
-        while True:
+        while self.loop_condition(end_time):
             average = self.get_volume()
             is_below_threshold = self.detect_volume_threshold(average)
             if is_below_threshold:
@@ -148,11 +153,12 @@ class ThresholdDetector():
             else:
                 self.stdout(1)
     
-    def timed_volume_detector(self, ):
+    def timed_volume_detector(self, end_time=None):
         """ Reads volumes from input audio stream and
             alerts if time and volume thresholds are exceeded
         """
-        while True:
+
+        while self.loop_condition(end_time):
             average = self.get_volume()
             is_below_threshold = self.detect_volume_threshold(average)
             above_time_threshold = self.detect_time_threshold()


### PR DESCRIPTION
Greg's comments:
1. In `test_and_restart_stream`, is there any possibility of an exception being raised where you would not want `self.create_stream()` to run? In other words, would it be better to define the exception in the try: except: block, or is that truly unnecessary?
2. Why is it necessary to run `time.sleep(1)` at the onset of calling `run`?
3. In `timed_volume_detector`, even with how short of a function it is, it's hard to lose track of how the `self.alerted_threshold`, `self.threshold_timestamp`, `self.was_at_threshold` and `self.alerted_threshold` attributes interact. Could you explain how that works, or do you have any ideas for how the code could be restructured so that it's more easily understandable?
4. Definitely appreciate you writing and including tests with this work. I got the following output when I ran the tests. What's going on there?

Pedro's responses:
1. `test_and_restart_stream` was a hack around an error that I was getting on line 112: when I was reading chunks I would get this exception: https://stackoverflow.com/questions/10733903/pyaudio-input-overflowed I think because my chunks were larger than the stream's buffer. Restarting the stream solved this. But I've eliminated that function in favor of the solution on that stackoverflow question, adding in line 112: `exception_on_overflow=False`, per the docs: https://people.csail.mit.edu/hubert/pyaudio/docs/#pyaudio.Stream.read
I think this is another hack, but I've tested it and there's no buggy behavior. A better solution would be to investigate the stream reading more closely to figure out how best to chunk without overflowing.
2. I don't think it is. Good catch!
3. I simplified the code, eliminating `self.was_at_threshold` and consolidating the if statements. You could also eliminate `self.alerted_threshold` if you didn't care about seeing `Time and volume thresholds met!` printed on each iteration until volume went above the threshold. Basically, on each iteration (each fraction of a second sample of volume), the function checks if the volume is below the threshold and above the time threshold. If the volume is above the threshold everything resets, but once it goes below the threshold once, it sets `self.threshold_timestamp` to start recording the time it has been below. In the `simple` detector, all it cares about is whether the current volume is below the threshold, whereas in this one it also cares about how long the volume has been below the threshold. 
4. Some of those failures were because I renamed the functions in this exercise (I haven't updated the tests in a long time) from to `timed_volume_detector` and to `simple_detector`. The other was a failing test, I corrected on line 20 threshold should be an int not a float.